### PR TITLE
完善debug、profiler的 数据帧下发：添加最大帧号下发。

### DIFF
--- a/service/swt/agent/handle_debug.lua
+++ b/service/swt/agent/handle_debug.lua
@@ -57,7 +57,7 @@ local function send_print(session, text)
         agent_send(
             session2id[session],
             "debug_print",
-            {session = session, text = string.sub(text, s, e), index = max - i}
+            {session = session, text = string.sub(text, s, e), index = max - i, max = max}
         )
     end
 end

--- a/service/swt/master/agent_mgr.lua
+++ b/service/swt/master/agent_mgr.lua
@@ -50,13 +50,13 @@ function mt:get(addr)
                 agent.name = msg.name
                 agent.type = msg.type
             elseif cmd == 'debug_print' then
-                local session, text, index = msg.session, msg.text, msg.index
+                local session, text, index, max = msg.session, msg.text, msg.index, msg.max
                 local cb = agent_mgr.sessions[session]
                 if not cb then
                     util.log_info("debug_print not exists session:%d", session)
                     return
                 end
-                cb("print", text, index)
+                cb("print", text, index, max)
             elseif cmd == 'debug_ret' then
                 local session, ret, output = msg.session, msg.ret, msg.output
                 local cb = agent_mgr.sessions[session]
@@ -117,9 +117,9 @@ function mt:debug_run(addr, script, target, print_cb)
     local ret, err
     local callback = function(type, ...)
         if type == "print" then
-            local text, index = ...
+            local text, index, max = ...
             if print_cb then
-                print_cb(text, index)
+                print_cb(text, index, max)
             else
                 if temp_print then
                     temp_print = temp_print .. text

--- a/service/swt/master/handle_api.lua
+++ b/service/swt/master/handle_api.lua
@@ -54,8 +54,8 @@ local function _debug_run(request, targets, script)
             target.node.addr,
             script,
             target.addr,
-            function(text, index)
-                response(target, "print", {text = text, index = index})
+            function(text, index, max)
+                response(target, "print", {text = text, index = index, max = max})
             end
         )
 

--- a/vue/src/views/debug/index.vue
+++ b/vue/src/views/debug/index.vue
@@ -97,7 +97,7 @@ import NodeFilter from '@/views/nodeFilter.vue'
 type DebugService = {
   base: Define.LuaService
   result: string
-  tempPrint: string
+  tempMap: any
 }
 
 @Component({
@@ -119,7 +119,7 @@ export default class extends Vue {
   onSelectNodeServiceChange(nodeServices: Define.LuaService[]) {
     this.curNodeServices = []
     nodeServices.forEach((node) => {
-      this.curNodeServices.push({ base: node, result: '', tempPrint: '' })
+      this.curNodeServices.push({ base: node, result: '', tempMap: null })
     })
     if (this.runAmount == 0) {
       this.currpage = 1
@@ -158,15 +158,24 @@ export default class extends Vue {
       for (let row of this.nodeServices) {
         // let row = this.nodeServices[k]
         if (row.base.node && msg.node_id == row.base.node.addr && msg.addr == row.base.addr) { // eslint-disable-line
-          if (msg.type == 'print') {
-            row.tempPrint += msg.msg.text
-
-            if (msg.msg.index == 0) {
-              row.result += `${msg.type}: ${row.tempPrint}\n`
-              row.tempPrint = ''
+          if (msg.type == 'error') {
+            row.result = `${msg.type}: ${msg.msg}\n`
+            row.tempMap = null
+          }else if (msg.type == 'print') {
+            if(row.tempMap == null){
+              row.tempMap = new Map()
+            }
+            row.tempMap.set(msg.msg.index, msg.msg.text)
+            if(row.tempMap.get(0) != undefined && row.tempMap.size >= msg.msg.max + 1){
+              let tempPrint = ""
+              for(var k = msg.msg.max; k >= 0; --k){
+                tempPrint += row.tempMap.get(k)
+              }
+              row.result = `${msg.type}: ${tempPrint}\n`
+              row.tempMap = null
             }
           } else {
-            row.result = row.result + `${msg.type}: ${msg.msg}\n`
+            row.result = `${msg.type}: ${msg.msg}\n`
           }
         }
       }

--- a/vue/src/views/profiler/index.vue
+++ b/vue/src/views/profiler/index.vue
@@ -122,7 +122,6 @@ type DebugService = {
   result: string
   error: string
   tempMap: any
-  tempMax: number
 }
 
 @Component({
@@ -252,7 +251,7 @@ export default class extends Vue {
   onSelectNodeServiceChange(nodeServices: Define.LuaService[]) {
     this.curNodeServices = []
     nodeServices.forEach((node) => {
-      this.curNodeServices.push({ base: node, result: '', error: '', tempMap: null, tempMax: -1 })
+      this.curNodeServices.push({ base: node, result: '', error: '', tempMap: null })
     })
 
     if (this.runAmount == 0) {
@@ -310,27 +309,18 @@ export default class extends Vue {
           if (msg.type == 'error') {
             row.error = msg.msg
             row.tempMap = null
-            row.tempMax = -1
-          }
-
-          if (msg.type == 'print') {
+          }else if (msg.type == 'print') {
             if(row.tempMap == null){
               row.tempMap = new Map()
             }
             row.tempMap.set(msg.msg.index, msg.msg.text)
-            if(msg.msg.index > row.tempMax){
-              row.tempMax = msg.msg.index
-            }
-
-            if(row.tempMap.get(0) != undefined){ // check ending
-              if(row.tempMap.size >= row.tempMax + 1){
-                row.result = ""
-                for(var k = row.tempMax; k >= 0; --k){
-                  row.result += row.tempMap.get(k)
-                }
-                row.tempMap = null
-                row.tempMax = -1
+            if(row.tempMap.get(0) != undefined && row.tempMap.size >= msg.msg.max + 1){
+              let tempPrint = ""
+              for(var k = msg.msg.max; k >= 0; --k){
+                tempPrint += row.tempMap.get(k)
               }
+              row.result = tempPrint
+              row.tempMap = null
             }
           }
         }


### PR DESCRIPTION
在多帧情况下，还是有机会index=0 的数据【最早】解析完成：
``` js
// check ending
if(row.tempMap.size >= row.tempMax + 1){
}
```
此时 if(1 >= 0+1) == true。
优化成，swt/agent 将最大帧号下发，表明有多少帧。

(另外：建议添加 MIT License 开源协议)
